### PR TITLE
Support Laravel 13, drop EOL Laravel 10

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.2, 8.3]
+        php: [8.2, 8.3, 8.4]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -23,19 +23,19 @@
         }
     ],
     "require": {
-        "php": "^8.1|^8.2|^8.3",
+        "php": "^8.2|^8.3|^8.4",
         "spatie/laravel-package-tools": "^1.14.0",
-        "illuminate/contracts": "^10.0|^11.0|^12.0"
+        "illuminate/contracts": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "doctrine/dbal": "^3.7",
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.8",
+        "nunomaduro/collision": "^8.1.1",
         "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^8.0",
+        "orchestra/testbench": "^9.0",
         "pestphp/pest": "^2.20",
-        "pestphp/pest-plugin-arch": "^2.0",
-        "pestphp/pest-plugin-laravel": "^2.0",
+        "pestphp/pest-plugin-arch": "^2.5",
+        "pestphp/pest-plugin-laravel": "^2.2.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -25,20 +25,20 @@
     "require": {
         "php": "^8.2|^8.3|^8.4",
         "spatie/laravel-package-tools": "^1.14.0",
-        "illuminate/contracts": "^11.0|^12.0|^13.0"
+        "illuminate/contracts": "^12.0|^13.0"
     },
     "require-dev": {
         "doctrine/dbal": "^3.7",
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^8.1.1",
-        "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^9.0",
-        "pestphp/pest": "^2.20",
-        "pestphp/pest-plugin-arch": "^2.5",
-        "pestphp/pest-plugin-laravel": "^2.2.0",
+        "nunomaduro/collision": "^8.0",
+        "nunomaduro/larastan": "^3.0",
+        "orchestra/testbench": "^10.0",
+        "pestphp/pest": "^3.0",
+        "pestphp/pest-plugin-arch": "^3.0",
+        "pestphp/pest-plugin-laravel": "^3.0",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0"
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Adds Laravel 13.x and drops Laravel 10 (EOL, its only remaining releases are flagged by unpatched security advisories, so Composer can no longer install it).

require: `php ^8.2|^8.3|^8.4` and `illuminate/contracts ^11.0|^12.0|^13.0;` 

dev deps lifted to the L11 floor (`testbench ^9.0` etc.); CI matrix php [8.2, 8.3, 8.4]. 

The L13-pinned release lives on the 13.x branch, to be tagged v13.0.0.